### PR TITLE
flexible cxx/cxxflags/ldflags for CI integration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,21 +6,25 @@ set -e
 OS=$(uname -s)
 ARCH=$(uname -m)
 
-if [ "${OS}" = "Linux" ]; then
-    alias gx1="g++ -O3 -c -fpic -fopenmp "
-    alias gx2="g++ -O3 -shared -fopenmp "
-elif [ "${OS}" = "Darwin" ]; then
-    if [ "${ARCH}" = "arm64" ]; then
-        compiler="/opt/homebrew/opt/llvm/bin/clang++"
-    else
-        compiler="/usr/local/opt/llvm/bin/clang++"
-    fi
-    alias gx1="${compiler} -O3 -c -fpic -fopenmp "
-    alias gx2="${compiler} -O3 -shared -fopenmp "
+if [ -n "$CXX" ]; then
+    compiler="$CXX"
 else
-    echo "Unsupported OS"
-    exit -1
+    if [ "${OS}" = "Linux" ]; then
+        compiler="g++"
+    elif [ "${OS}" = "Darwin" ]; then
+        if [ "${ARCH}" = "arm64" ]; then
+            compiler="/opt/homebrew/opt/llvm/bin/clang++"
+        else
+            compiler="/usr/local/opt/llvm/bin/clang++"
+        fi
+    else
+        echo "Unsupported OS"
+        exit -1
+    fi
 fi
+
+alias gx1="${compiler} \$CXXFLAGS -O3 -c -fpic -fopenmp "
+alias gx2="${compiler} \$LDFLAGS -O3 -shared -fopenmp "
 
 mkdir -p ocmesher/lib
 gx1 -o ocmesher/lib/core.o ocmesher/source/core.cpp


### PR DESCRIPTION
While debugging build issues with `infinigen`/`cibuildwheel`, it seems like we need to be able to flexibly specify the compiler/compiler flags/linker flags from envvars in the CI (the default paths are runner-dependent, for example). This is needed both for the `infinigen` bash scripts as well as the `OcMesher` `install.sh` script.

These are the minimal changes I can think of that will allow us to do this, without breaking existing behavior.

Since `infinigen` is pinned to commit d3d1441 of `OcMesher` (and it insists that `assert ocmesher_version == "1.0"` at certain places), this is where those changes should be made. However, I don't have permissions to create branches on this repo (and there does seem to be a way to send a PR towards a particular commit and not a branch).

Once this is merged, then the submodule pointing to this repo in `infinigen` can be updated.